### PR TITLE
Implement CanvasGroupController

### DIFF
--- a/Assets/Scripts/Connector/Controller/CanvasGroupController.cs
+++ b/Assets/Scripts/Connector/Controller/CanvasGroupController.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using UniRx;
+using UnityEngine;
+
+namespace UniFlow.Connector.Controller
+{
+    [AddComponentMenu("UniFlow/Controller/CanvasGroupController", (int) ConnectorType.CanvasGroupController)]
+    public class CanvasGroupController: ConnectorBase
+    {
+        [SerializeField] private CanvasGroupControlMethod canvasGroupControlMethod = CanvasGroupControlMethod.Activate;
+        [SerializeField] private List<CanvasGroup> canvasGroups = default;
+
+        [UsedImplicitly] private CanvasGroupControlMethod CanvasGroupControlMethod
+        {
+            get => canvasGroupControlMethod;
+            set => canvasGroupControlMethod = value;
+        }
+        [UsedImplicitly] private IEnumerable<CanvasGroup> CanvasGroups
+        {
+            get => canvasGroups;
+            set => canvasGroups = value.ToList();
+        }
+
+        private IDisposable Disposable { get; } = new CompositeDisposable();
+
+        public override IObservable<IMessage> OnConnectAsObservable(IMessage latestMessage)
+        {
+            var count = HandleActivation();
+            return Observable.Return(Message.Create(this, count));
+        }
+
+        private int HandleActivation()
+        {
+            var targets = CanvasGroups.Where(x => x.blocksRaycasts != (CanvasGroupControlMethod == CanvasGroupControlMethod.Activate)).ToList();
+            var count = targets.Count;
+            targets.ForEach(x => x.blocksRaycasts = CanvasGroupControlMethod == CanvasGroupControlMethod.Activate);
+            return count;
+        }
+
+        public class Message : MessageBase<CanvasGroupController, int>, IValueHolder<int>
+        {
+            public static Message Create(CanvasGroupController sender, int count)
+            {
+                return Create<Message>(ConnectorType.CanvasGroupController, sender, count);
+            }
+
+            public int Value => Data;
+        }
+    }
+
+    [PublicAPI]
+    public enum CanvasGroupControlMethod
+    {
+        Activate,
+        Deactivate,
+    }
+}

--- a/Assets/Scripts/Connector/Controller/CanvasGroupController.cs.meta
+++ b/Assets/Scripts/Connector/Controller/CanvasGroupController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9e1f7c433e1240e7854e2a646fc731c6
+timeCreated: 1569115875

--- a/Assets/Scripts/ConnectorType.cs
+++ b/Assets/Scripts/ConnectorType.cs
@@ -33,6 +33,7 @@ namespace UniFlow
         RaycasterController,
         RaycastTargetController,
         MoveParentTransform,
+        CanvasGroupController,
 
         LoadScene                 = 400,
         LoadScene_Enum,


### PR DESCRIPTION
`CanvasGroup.blocksRaycasts` is so useful for activating / deactivating all the raycast targets of its child components.

However, I have two concerns for this pull request.

The first is this component name might be too broad, because `CavasGroup` has more than `blockRaycasts` feature, like changing `alpha`. 

Moreover, UniFlow has `RaycastTargetController` component, so I think this component could be included in `RaycastTargetController`.