### PR TITLE
Add BoolToggle

### DIFF
--- a/Assets/Scripts/Connector/Logic/BoolToggle.cs
+++ b/Assets/Scripts/Connector/Logic/BoolToggle.cs
@@ -1,0 +1,45 @@
+using System;
+using JetBrains.Annotations;
+using UniRx;
+using UnityEngine;
+
+namespace UniFlow.Connector.Logic
+{
+    [AddComponentMenu("UniFlow/Logic/BoolToggle", (int) ConnectorType.BoolToggle)]
+    public class BoolToggle : ConnectorBase
+    {
+        [SerializeField] private bool initialValue = false;
+
+        [UsedImplicitly] public bool InitialValue
+        {
+            get => initialValue;
+            set => initialValue = value;
+        }
+
+        private bool Value { get; set; }
+
+        protected override void Awake()
+        {
+            base.Awake();
+            Value = InitialValue;
+        }
+
+        public override IObservable<IMessage> OnConnectAsObservable(IMessage latestMessage)
+        {
+            var result = Observable.Return(Message.Create(this, Value));
+            Value = !Value;
+
+            return result;
+        }
+
+        public class Message : MessageBase<BoolToggle, bool>, IValueHolder<bool>
+        {
+            public static Message Create(BoolToggle sender, bool data)
+            {
+                return Create<Message>(ConnectorType.BoolToggle, sender, data);
+            }
+
+            bool IValueHolder<bool>.Value => Data;
+        }
+    }
+}

--- a/Assets/Scripts/Connector/Logic/BoolToggle.cs.meta
+++ b/Assets/Scripts/Connector/Logic/BoolToggle.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6b628d8b8dd54e85a16e54a19f17c079
+timeCreated: 1569669059

--- a/Assets/Scripts/ConnectorType.cs
+++ b/Assets/Scripts/ConnectorType.cs
@@ -52,6 +52,7 @@ namespace UniFlow
         Interval,
         TimeScaleController,
         Empty,
+        BoolToggle,
 
         Toss                      = 9100,
         Receive                   = 9101,


### PR DESCRIPTION
`BoolToggle` provides a bool value with toggling its value. For the first time it provides `InitialValue` you set, and for the second time it does ***not*** `InitialValue`.

My concern is there is a `ValueProvider` category, and whether this should belong to it.