### PR TITLE
Change timing for prepare connector

### DIFF
--- a/Assets/Scripts/Connector/Controller/PlayableController.cs
+++ b/Assets/Scripts/Connector/Controller/PlayableController.cs
@@ -43,18 +43,19 @@ namespace UniFlow.Connector.Controller
             set => timelineAsset = value;
         }
 
-        private void Awake()
+        public override IObservable<Unit> OnConnectAsObservable()
+        {
+            PreparePlayableDirector();
+            InvokePlayableDirectorMethod();
+            return Observable.ReturnUnit();
+        }
+
+        private void PreparePlayableDirector()
         {
             if (PlayableDirector != default && TimelineAsset != default)
             {
                 PlayableDirector.playableAsset = TimelineAsset;
             }
-        }
-
-        public override IObservable<Unit> OnConnectAsObservable()
-        {
-            InvokePlayableDirectorMethod();
-            return Observable.ReturnUnit();
         }
 
         private void InvokePlayableDirectorMethod()

--- a/Assets/Scripts/Connector/Controller/SimpleAnimationController.cs
+++ b/Assets/Scripts/Connector/Controller/SimpleAnimationController.cs
@@ -73,11 +73,12 @@ namespace UniFlow.Connector.Controller
 
         public override IObservable<Unit> OnConnectAsObservable()
         {
+            PrepareSimpleAnimation();
             InvokeSimpleAnimationMethod();
             return Observable.ReturnUnit();
         }
 
-        private void Awake()
+        private void PrepareSimpleAnimation()
         {
             // ReSharper disable once InvertIf
             // Automatic add components Animator and SimpleAnimation if AudioClip specified and Animator component does not exists.

--- a/Assets/Scripts/Connector/Event/AnimationEvent.cs
+++ b/Assets/Scripts/Connector/Event/AnimationEvent.cs
@@ -71,11 +71,7 @@ namespace UniFlow.Connector.Event
 
         public override IObservable<Unit> OnConnectAsObservable()
         {
-            if (AnimationClip != default && GetComponent<Animator>() == default && SimpleAnimation.GetStates().All(x => x.clip != AnimationClip))
-            {
-                SimpleAnimation.AddClip(AnimationClip, AnimationClip.GetInstanceID().ToString());
-            }
-
+            PrepareAnimationEvent();
             return Subject
                 // Prevents the previous flow from being re-invoked when triggered multiple times
                 .Take(1)
@@ -93,7 +89,7 @@ namespace UniFlow.Connector.Event
             Subject.OnNext(animationEvent);
         }
 
-        protected override void Start()
+        private void PrepareAnimationEvent()
         {
             // ReSharper disable once InvertIf
             // Automatic add components Animator and SimpleAnimation if AudioClip specified and Animator component does not exists.
@@ -103,7 +99,6 @@ namespace UniFlow.Connector.Event
                 SimpleAnimation.cullingMode = CullingMode;
                 Animator.updateMode = UpdateMode;
             }
-            base.Start();
         }
     }
 }

--- a/Assets/Scripts/Connector/Event/SimpleAnimationEvent.cs
+++ b/Assets/Scripts/Connector/Event/SimpleAnimationEvent.cs
@@ -61,14 +61,9 @@ namespace UniFlow.Connector.Event
 
         private IDictionary<SimpleAnimation.State, bool> PlayingStatuses { get; } = new Dictionary<SimpleAnimation.State, bool>();
 
-        protected override void Start()
-        {
-            ObserveSimpleAnimation();
-            base.Start();
-        }
-
         public override IObservable<Unit> OnConnectAsObservable()
         {
+            ObserveSimpleAnimation();
             return CurrentStateSubject
                 .Where(x => (AnimationClip == default || x.animationClip == AnimationClip) && x.eventType == SimpleAnimationEventType)
                 .AsUnitObservable();
@@ -89,7 +84,7 @@ namespace UniFlow.Connector.Event
 
         private void OnChangeAnimatorStateInfo(Pair<(bool isPlaying, float normalizedTime)> pair, SimpleAnimation.State state)
         {
-            if (!pair.Previous.isPlaying && pair.Current.isPlaying && !PlayingStatuses[state])
+            if (pair.Current.isPlaying && !PlayingStatuses[state])
             {
                 PlayingStatuses[state] = true;
                 CurrentStateSubject.OnNext((SimpleAnimationEventType.Play, state.clip));


### PR DESCRIPTION
Fixed a problem that event subscription is not performed when GameObject is overwritten by `[ValueReceiver]`