### PR TITLE
Merge MessageAnnotations recursively

### DIFF
--- a/Assets/Scripts/Connector/Controller/InstantiateGameObject.cs
+++ b/Assets/Scripts/Connector/Controller/InstantiateGameObject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UniFlow.Utility;
 using UnityEngine;
 using Zenject;
@@ -31,7 +32,7 @@ namespace UniFlow.Connector.Controller
         private GameObjectCollector SourceCollector => sourceCollector;
         private TransformCollector ParentCollector => parentCollector;
 
-        private GameObject Instantiated { get; set; }
+        protected GameObject Instantiated { get; set; }
 
         [Inject] private DiContainer DiContainer { get; }
 
@@ -41,17 +42,27 @@ namespace UniFlow.Connector.Controller
             return ObservableFactory.ReturnMessage(this, nameof(Instantiated), Instantiated);
         }
 
-        IEnumerable<ICollectableMessageAnnotation> IMessageCollectable.GetMessageCollectableAnnotations() =>
-            new[]
-            {
-                CollectableMessageAnnotationFactory.Create(SourceCollector, x => Source = x, nameof(Source)),
-                CollectableMessageAnnotationFactory.Create(ParentCollector, x => Parent = x, nameof(Parent)),
-            };
+        protected override IEnumerable<ICollectableMessageAnnotation> MergeMessageCollectableAnnotations() =>
+            base.MergeMessageCollectableAnnotations()
+                .Concat(
+                    new[]
+                    {
+                        CollectableMessageAnnotationFactory.Create(SourceCollector, x => Source = x, nameof(Source)),
+                        CollectableMessageAnnotationFactory.Create(ParentCollector, x => Parent = x, nameof(Parent)),
+                    }
+                );
 
-        IEnumerable<IComposableMessageAnnotation> IMessageComposable.GetMessageComposableAnnotations() =>
-            new[]
-            {
-                ComposableMessageAnnotationFactory.Create<GameObject>(nameof(Instantiated)),
-            };
+        protected override IEnumerable<IComposableMessageAnnotation> MergeMessageComposableAnnotations() =>
+            base.MergeMessageComposableAnnotations()
+                .Concat(
+                    new[]
+                    {
+                        ComposableMessageAnnotationFactory.Create<GameObject>(nameof(Instantiated)),
+                    }
+                );
+
+        IEnumerable<ICollectableMessageAnnotation> IMessageCollectable.GetMessageCollectableAnnotations() => MergeMessageCollectableAnnotations();
+
+        IEnumerable<IComposableMessageAnnotation> IMessageComposable.GetMessageComposableAnnotations() => MergeMessageComposableAnnotations();
     }
 }

--- a/Assets/Scripts/ConnectorBase.cs
+++ b/Assets/Scripts/ConnectorBase.cs
@@ -70,6 +70,12 @@ namespace UniFlow
             }
         }
 
+        protected virtual IEnumerable<ICollectableMessageAnnotation> MergeMessageCollectableAnnotations() =>
+            new ICollectableMessageAnnotation[0];
+
+        protected virtual IEnumerable<IComposableMessageAnnotation> MergeMessageComposableAnnotations() =>
+            new IComposableMessageAnnotation[0];
+
         void IConnector.Connect(IObservable<Message> source)
         {
 #if UNITY_EDITOR


### PR DESCRIPTION
If you need to merge `IEnumerable<I(Composable|Collectable)MessageAnnotations>`, implement methods as below.

```csharp
IEnumerable<ICollectableMessageAnnotation> IMessageCollectable.GetMessageCollectableAnnotations() => MergeMessageCollectableAnnotations();

protected override IEnumerable<ICollectableMessageAnnotation> MergeMessageCollectableAnnotations() =>
    base.MergeMessageCollectableAnnotations()
        .Concat(
            new[]
            {
                CollectableMessageAnnotationFactory.Create(...),
            }
        );

IEnumerable<IComposableMessageAnnotation> IMessageComposable.GetMessageComposableAnnotations() => MergeMessageComposableAnnotations();

protected override IEnumerable<IComposableMessageAnnotation> MergeMessageComposableAnnotations() =>
    base.MergeMessageComposableAnnotations()
        .Concat(
            new[]
            {
                ComposableMessageAnnotationFactory.Create(...),
            }
        );
```